### PR TITLE
Resolved broken QR code issue.

### DIFF
--- a/src/Paynow.php
+++ b/src/Paynow.php
@@ -287,13 +287,18 @@ class Paynow
 		
 		// Here we add "6304" to the previous string
 		// ID 63 (Checksum) 04 (4 characters)
+		$output .= '6304';
+		
 		// Do a CRC16 of the whole string including the "6304"
-		// then append it to the end.
-		$output .= '6304' . CRC16::calculate($output . '6304');
+		$crc16CalcOutput = $this->padLeft(CRC16::calculate($output), 4);
+		
+		// then append the computed val. to the $output var.
+		$output .= $crc16CalcOutput;
+		
 		if ($this->createAsBase64Image) {
 			$output = $this->createAsBase64Image($output);
 		}
-
+		
 		return $output;
 	}
 
@@ -340,9 +345,14 @@ class Paynow
 		
 		// Here we add "6304" to the previous string
 		// ID 63 (Checksum) 04 (4 characters)
+		$output .= '6304';
+		
 		// Do a CRC16 of the whole string including the "6304"
-		// then append it to the end.
-		$output .= '6304' . CRC16::calculate($output . '6304');
+		$crc16CalcOutput = $this->padLeft(CRC16::calculate($output), 4);
+		
+		// then append the computed val. to the $output var.
+		$output .= $crc16CalcOutput;
+		
 		if ($this->createAsBase64Image) {
 			$output = $this->createAsBase64Image($output);
 		}


### PR DESCRIPTION
During stress testing, it was observed that some QR codes were failing to read. It was found that the CRC16::calculate() function returned only three characters instead of four. To address this issue, the padLeft function was utilized which resulted in successfully resolving the broken QR Code issue. 

To Replicate: 
To fire atleast a 100+ QR within a minute and to try scanning the QR codes. The ones that fail to scan, when you recalculate the CRC16 (https://crccalc.com/), it will be a different value compared to the one returned by the CRC16::calculate function. 

Thanks. Hope this helps. 